### PR TITLE
fix(ts): fixed type imports for generated dist type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1876,9 +1876,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.0.tgz",
-      "integrity": "sha512-WE4IOAC6r/yBZss1oQGM5zs2D7RuKR6Q+w+X2SouPofnWn+LbCqClRyhO3ZE7Ix8nmFgo/oVuuE01cJT2XB13A=="
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.1.tgz",
+      "integrity": "sha512-NXKvBVUzIbs6ylBwmOwHFkZS2EXCcjnqr8ZCRNaXBkHAf+3mn/rPcJxwrzuc6movh8fxQAsUUfYklJ/EG+hZqQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1905,9 +1906,10 @@
       "dev": true
     },
     "@types/readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-Mq2eLkGYamlcolW603FY2ROBvcl90jPF+3jLkjpBV6qS+2aVeJqlgRG0TVAa1oWbmPdb5yOWlOPVvQle76nUNw==",
+      "version": "2.3.12",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.12.tgz",
+      "integrity": "sha512-IVe0ietigIRWjRg0gv2sydr0rhyPzdXQsBMU/gda8fl82xQL+J9UWRBcD0asxoe4pb5wTOsPrOz0KYJZVCXZJQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "safe-buffer": "*"
@@ -12706,7 +12708,8 @@
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@types/dotenv": "^8.2.0",
     "@types/jest": "^25.1.3",
     "@types/qs": "^6.9.1",
+    "@types/readable-stream": "^2.3.12",
     "@types/serialize-error": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/eslint-plugin-tslint": "^4.12.0",
@@ -145,7 +146,6 @@
   },
   "dependencies": {
     "@types/just-safe-get": "^1.3.0",
-    "@types/readable-stream": "^2.3.5",
     "@types/tapable": "^1.0.5",
     "axios": "0.21.1",
     "date-fns": "^2.20.1",

--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -1,6 +1,6 @@
 
 import qs from 'qs'
-import { Client } from 'src/client'
+import { Client } from '../../../client'
 import { APICarrier } from '../../../base'
 import Entity, { EntityFetchOptions, EntityOptions } from '../../../entities/_base'
 import { BaseError } from '../../../errors'

--- a/src/entities/_base/index.ts
+++ b/src/entities/_base/index.ts
@@ -1,6 +1,6 @@
 import omit from 'just-omit'
 import { EventEmitter } from 'events'
-import { Readable, pipeline } from 'readable-stream'
+import { Readable } from 'readable-stream'
 import {
   SyncHook, SyncBailHook, SyncWaterfallHook, SyncLoopHook, AsyncParallelHook,
   AsyncParallelBailHook, AsyncSeriesHook, AsyncSeriesBailHook, AsyncSeriesWaterfallHook
@@ -451,8 +451,6 @@ export abstract class EntitiesList<Entity, RawPayload> extends Readable {
   // toJson (list: Entity[]): RawPayload[] {
   //   return list.map((item: Entity) => (item.serialize()))
   // }
-
-  static pipeline = pipeline
 
   public abstract getStream (options?: EntitiesListFetchOptions): Promise<EntitiesList<Entity, RawPayload>>
 

--- a/src/entities/crm/crm.ts
+++ b/src/entities/crm/crm.ts
@@ -3,7 +3,7 @@ import { UniverseEntityOptions, UniverseEntity, EntityFetchOptions } from '../_b
 import { Universe } from '../../universe'
 import { BaseError } from '../../errors'
 import qs from 'qs'
-import { AssociateUsersPayload, CrmUser } from 'src/entities/crm/crm-user'
+import { AssociateUsersPayload, CrmUser } from '../../entities/crm/crm-user'
 
 export interface CRMOptions extends UniverseEntityOptions {
   rawPayload?: CRMRawPayload


### PR DESCRIPTION
I was working on enabling typescript support for the agent UI, but it turns out that the SDK is not really compatible with using with typescript codebase. This PR fixes that problem.

* changed `src/...` import paths to relative paths e.g. `../../...`
* removed reference to `pipeline` function exported from `readable-stream` package. it is used as a static property on `EntitiesList` class, and seemingly not used anywhere. The problem with the funciton is that it is not typed by `@types/readable-stream` package and the signature is quite complex (see [Node Stream pipeline typing](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v14/stream.d.ts#L301-L326)). If needed we could adapt it to make it available and properly typed, but I found no evidence of that being useful.

PHAL Thanks!