### PR TITLE
feat(message subscriptions): update message subscriptions

### DIFF
--- a/src/entities/message-template/message-template.ts
+++ b/src/entities/message-template/message-template.ts
@@ -43,6 +43,45 @@ export interface MessageTemplateRawPayloadCarousel {
   items?: MessageTemplateRawPayloadCarouselItem[]
 }
 
+export interface MessageTemplateRawPayloadQuickReply {
+  type?: 'text' | string | null
+  payload?: string | null
+  text?: string
+  image_url?: string
+}
+
+export interface MessageTemplateRawPayloadLocalizedContent {
+  locale?: string
+  status?: string
+  rejection_reason?: string | null
+  body?: string
+  header?: {
+    type?: 'text' | string | null
+    payload?: string | null
+  } | null
+  footer?: {
+    type?: 'text' | null
+    payload?: string
+  } | null
+  attachments?: MessageTemplateRawPayloadAttachment[] | MessageTemplateRawPayloadLocation[] | MessageTemplateRawPayloadCarousel[] | any
+  approved?: boolean
+  quick_replies?: {
+    translate?: boolean
+    translation_prepend?: string | null
+    translation_append?: string | null
+    replies?: MessageTemplateRawPayloadQuickReply[]
+  }
+}
+
+export type MessageTemplateRawPayloadParameters = {
+  [key: string]: any
+} | Array<{
+  name?: string
+  required?: boolean | null
+  order_index?: number
+  logic?: object| null
+}>
+
 export interface MessageTemplateRawPayload {
   readonly id?: string
   readonly created_at?: string
@@ -61,45 +100,14 @@ export interface MessageTemplateRawPayload {
     body?: string | null
     // DEPRECATED
     attachments?: MessageTemplateRawPayloadAttachment[] | null
-    i18n?: Array<{
-      locale?: string
-      status?: string
-      rejection_reason?: string | null
-      body?: string
-      header?: {
-        type?: 'text' | string | null
-        payload?: string | null
-      } | null
-      footer?: {
-        type?: 'text' | null
-        payload?: string
-      } | null
-      attachments?: MessageTemplateRawPayloadAttachment[] | MessageTemplateRawPayloadLocation[] | MessageTemplateRawPayloadCarousel[] | any
-      approved?: boolean
-      quick_replies?: {
-        translate?: boolean
-        translation_prepend?: string | null
-        translation_append?: string | null
-        replies?: Array<{
-          type?: 'text' | string | null
-          payload?: string | null
-          text?: string
-          image_url?: string
-        }>
-      }
-    }> | null
+    i18n?: MessageTemplateRawPayloadLocalizedContent[] | null
   } | null
   readonly configuration?: object
   readonly payload?: object
   readonly metadata?: object
   readonly parameters_template?: {
     type?: 'list' | 'map'
-    parameters?: { [key: string]: any } | Array<{
-      name?: string
-      required?: boolean | null
-      order_index?: number
-      logic?: object| null
-    }>
+    parameters?: MessageTemplateRawPayloadParameters
   } | null
   readonly notification?: boolean
   readonly content_category?: string

--- a/src/universe/index.ts
+++ b/src/universe/index.ts
@@ -144,6 +144,11 @@ export interface UniverseExportCsvOptions {
   query?: UniverseFetchQuery
 }
 
+export interface UniverseFetch<E, R> {
+  (options?: UniverseFetchOptions & { raw: true }): Promise<R | undefined>
+  (options?: UniverseFetchOptions): Promise<E | undefined>
+}
+
 export declare interface Universe {
   on: ((event: 'raw-error' | 'error', cb: (error: Error) => void) => this) & ((event:
   'armed' // currently unused
@@ -300,8 +305,7 @@ export interface IUniverseImports {
 }
 
 export interface IUniverseMessageSubscriptions {
-  fetch: ((options?: UniverseFetchOptions & { raw: true }) => Promise<messageSubscription.MessageSubscriptionRawPayload[] | undefined>)
-  & ((options?: UniverseFetchOptions) => Promise<messageSubscription.MessageSubscription[] | undefined>)
+  fetch: UniverseFetch<messageSubscription.MessageSubscription[], messageSubscription.MessageSubscriptionRawPayload[]>
   fromJson: (messageSubscriptions: messageSubscription.MessageSubscriptionPayload[]) => messageSubscription.MessageSubscription[]
   toJson: (messageSubscriptions: messageSubscription.MessageSubscription[]) => messageSubscription.MessageSubscriptionPayload[]
   fetchCount: (options?: EntityFetchOptions) => Promise<{ count: number }>

--- a/src/universe/index.ts
+++ b/src/universe/index.ts
@@ -299,6 +299,14 @@ export interface IUniverseImports {
   fetchCount: (options?: EntityFetchOptions) => Promise<{ count: number }>
 }
 
+export interface IUniverseMessageSubscriptions {
+  fetch: ((options?: UniverseFetchOptions & { raw: true }) => Promise<messageSubscription.MessageSubscriptionRawPayload[] | undefined>)
+  & ((options?: UniverseFetchOptions) => Promise<messageSubscription.MessageSubscription[] | undefined>)
+  fromJson: (messageSubscriptions: messageSubscription.MessageSubscriptionPayload[]) => messageSubscription.MessageSubscription[]
+  toJson: (messageSubscriptions: messageSubscription.MessageSubscription[]) => messageSubscription.MessageSubscriptionPayload[]
+  fetchCount: (options?: EntityFetchOptions) => Promise<{ count: number }>
+}
+
 export class UniverseUnauthenticatedError extends BaseError {
   public name = 'UniverseUnauthenticatedError'
   constructor (public message: string = 'Invalid or expired session.', properties?: any) {
@@ -2097,7 +2105,61 @@ export class Universe extends APICarrier {
     }
   }
 
-  public async messageSubscriptions (options?: EntityFetchOptions): Promise<messageSubscription.MessageSubscription[] | messageSubscription.MessageSubscriptionRawPayload[] | undefined> {
+  public get messageSubscriptions (): IUniverseMessageSubscriptions {
+    return {
+      fromJson: (payloads: messageSubscription.MessageSubscriptionPayload[]): messageSubscription.MessageSubscription[] => {
+        return payloads.map((item) => (messageSubscription.MessageSubscription.create(item, this, this.http)))
+      },
+      toJson: (payloads: messageSubscription.MessageSubscription[]): messageSubscription.MessageSubscriptionPayload[] => {
+        return payloads.map((item) => (item.serialize()))
+      },
+      fetch: async (options?: UniverseFetchOptions): Promise<any> => {
+        try {
+          const opts = {
+            method: 'GET',
+            url: `${this.universeBase}/${messageSubscription.MessageSubscriptions.endpoint}`,
+            params: {
+              ...(options?.query ?? {})
+            }
+          }
+
+          const res = await this.http.getClient()(opts)
+          const resources = res.data.data as messageSubscription.MessageSubscriptionRawPayload[]
+
+          if (options && options.raw === true) {
+            return resources
+          }
+
+          return resources.map((resource: messageSubscription.MessageSubscriptionPayload) => {
+            return messageSubscription.MessageSubscription.create(resource, this, this.http)
+          })
+        } catch (err) {
+          throw new messageSubscription.MessageSubscriptionFetchRemoteError(undefined, { error: err })
+        }
+      },
+      fetchCount: async (options?: UniverseFetchOptions): Promise<{ count: number }> => {
+        try {
+          const opts = {
+            method: 'HEAD',
+            url: `${this.universeBase}/${messageSubscription.MessageSubscriptions.endpoint}`,
+            params: {
+              ...(options?.query ?? {})
+            }
+          }
+
+          const res = await this.http.getClient()(opts)
+
+          return {
+            count: Number(res.headers['X-Resource-Count'] || res.headers['x-resource-count'])
+          }
+        } catch (err) {
+          throw new messageSubscription.MessageSubscriptionFetchRemoteError(undefined, { error: err })
+        }
+      }
+    }
+  }
+
+  public async fetchMessageSubscriptions (options?: EntityFetchOptions): Promise<messageSubscription.MessageSubscription[] | messageSubscription.MessageSubscriptionRawPayload[] | undefined> {
     return await this.makeBaseResourceListRequest<messageSubscription.MessageSubscription, messageSubscription.MessageSubscriptions, messageSubscription.MessageSubscriptionRawPayload, EntityFetchOptions, messageSubscription.MessageSubscriptionsFetchRemoteError>(messageSubscription.MessageSubscription, messageSubscription.MessageSubscriptions, messageSubscription.MessageSubscriptionsFetchRemoteError, options)
   }
 


### PR DESCRIPTION
In the scope of opt-ins feature development:

* added missing types on Message Subscription interface
* added `duplicate` method for a message subscription entity
* implemented `fetch` interface for `messageSubscriptions`  on `universe` to work with Data Table on agent ui

https://app.clickup.com/t/24327122/TECH-552
