### PR TITLE
Fix: TECH-1548 Subscriber base analytics report for Message Opt-ins Overview

### DIFF
--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -49,9 +49,34 @@ export interface SubscriptionsAnalyticsSummaryReport {
   summary: number
 }
 
+export interface SubscriberBaseAnalyticsReport {
+  count: number
+  created_at: string
+  metric: AnalyticsReportMetric
+  values: Array<[string, number]>
+}
+
+export interface SubscriberBaseAnalyticsSummaryReport {
+  created_at: string
+  metric: AnalyticsReportMetric
+  summary: number
+}
+
+export interface TotalSubscriberBaseAnalyticsReport {
+  created_at: string
+  metric: AnalyticsReportMetric
+  total: number
+}
+
 export type SubscriptionAnalyticsResponse = [
   SubscriptionsAnalyticsReport,
   SubscriptionsAnalyticsReport,
   SubscriptionsAnalyticsSummaryReport,
   SubscriptionsAnalyticsSummaryReport
+]
+
+export type SubscriberBaseAnalyticsResponse = [
+  SubscriberBaseAnalyticsReport,
+  SubscriberBaseAnalyticsSummaryReport,
+  TotalSubscriberBaseAnalyticsReport
 ]

--- a/src/universe/index.ts
+++ b/src/universe/index.ts
@@ -18,7 +18,8 @@ import {
   ANALYTICS_ENDPOINT,
   AnalyticsFetchRemoteError,
   AnalyticsReport,
-  SubscriptionAnalyticsResponse
+  SubscriptionAnalyticsResponse,
+  SubscriberBaseAnalyticsResponse
 } from '../analytics/analytics'
 
 import * as staff from '../entities/staff/staff'
@@ -244,6 +245,7 @@ export interface UniverseAnalytics {
   orders: (options: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
   revenues: (options: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
   xau: (options: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
+  subscriberBaseEvents: (options: UniverseAnalyticsEventsOptions) => Promise<SubscriberBaseAnalyticsResponse | undefined>
   subscriptionEventsBySubscriptionId: (subscriptionId: string, options: UniverseAnalyticsEventsOptions) => Promise<SubscriptionAnalyticsResponse | undefined>
   subscriptionEvents: (options: UniverseAnalyticsEventsOptions) => Promise<SubscriptionAnalyticsResponse | undefined>
   feedOpenedClosed: (options: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
@@ -1036,6 +1038,9 @@ export class Universe extends APICarrier {
       },
       xau: async (options: UniverseAnalyticsOptions): Promise<AnalyticsReport[]> => {
         return await this.makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>('/messages/xau/count', options)
+      },
+      subscriberBaseEvents: async (options: UniverseAnalyticsEventsOptions): Promise<SubscriberBaseAnalyticsResponse | undefined> => {
+        return await this.makeAnalyticsRequest<SubscriberBaseAnalyticsResponse, UniverseAnalyticsEventsOptions>('/events/subscriptions/subscriber_base', options)
       },
       subscriptionEventsBySubscriptionId: async (subscriptionId: string, options: UniverseAnalyticsEventsOptions): Promise<SubscriptionAnalyticsResponse | undefined> => {
         return await this.makeAnalyticsRequest<SubscriptionAnalyticsResponse, UniverseAnalyticsEventsOptions>(`/events/subscriptions/${subscriptionId}`, options)


### PR DESCRIPTION
## Summary

<!-- (Briefly summarize the changes that have been made to the platform) -->

The total subscribers number and the dashboard in the **Message Opt-ins Overview** show the total subscriber base and its distribution over a selected period. Whereas the **Message Opt-ins Details** view shows the subscriptions and their opt-ins and opt-outs amongst others.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to not work as expected)~
- [ ] ~This change requires a documentation update~

### What is the feature/ What was the bug?

<!-- (Describe what the feature is or insert link to ticket) -->

https://app.clickup.com/t/24327122/TECH-1548

### What is the solution?

<!-- (Describe at a high level how the feature/fix was implemented) -->

- create a new analytics report endpoint to surface subscriber base data
- reroute the **Message Opt-ins Overview** to consume the subscriber base analytics report instead of the subscriptions analytics report
- add new endpoint and typing to browser-sdk

### What areas of the site does it impact?

<!-- (Describe what parts of the site are impacted and*if*code touched other areas) -->

- [agent-ui](https://github.com/c-commerce/charles-agent-ui/pull/1211#issue-1218740203): `src/components/automation/subscriptions/overview/OverviewDashboard.vue`
- [client-api](https://github.com/c-commerce/charles-client-api/pull/589#issue-1218733689): `lib/handlers/analytics/subscriptions/subscriber_base.js`
- browser-sdk: `src/analytics/analytics.ts`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
