### PR TITLE
fix(releases.ts): update definition of release entity

### DIFF
--- a/src/cloud/entities/releases/releases.ts
+++ b/src/cloud/entities/releases/releases.ts
@@ -15,16 +15,21 @@ export interface ReleaseRawPayload {
   readonly active?: boolean
   readonly name?: string
   readonly status?: string
-  readonly configuration?: {
-    [key: string]: any
+
+  readonly allVersions?: {
+    readonly version?: any
   }
+  readonly configuration?: any
   readonly product?: string
   readonly product_name?: string
   readonly channel?: string
   readonly default_display_name?: string
+  readonly organization?: string
+  readonly pool?: string
+  readonly release?: string
 }
 
-export interface ReleasePaylod {
+export interface ReleasePayload {
   readonly id?: ReleaseRawPayload['id']
   readonly createdAt?: Date | null
   readonly updatedAt?: Date | null
@@ -32,11 +37,15 @@ export interface ReleasePaylod {
   readonly active?: ReleaseRawPayload['active']
   readonly name?: ReleaseRawPayload['name']
   readonly status?: ReleaseRawPayload['status']
+  readonly allVersions?: ReleaseRawPayload['allVersions']
   readonly configuration?: ReleaseRawPayload['configuration']
   readonly product?: ReleaseRawPayload['product']
   readonly productName?: ReleaseRawPayload['product_name']
   readonly channel?: ReleaseRawPayload['channel']
   readonly defaultDisplayName?: ReleaseRawPayload['default_display_name']
+  readonly organization?: ReleaseRawPayload['organization']
+  readonly pool?: ReleaseRawPayload['pool']
+  readonly release?: ReleaseRawPayload['release']
 }
 
 /**
@@ -44,7 +53,7 @@ export interface ReleasePaylod {
  *
  * @category Entity
  */
-export class Release extends Entity<ReleasePaylod, ReleaseRawPayload> {
+export class Release extends Entity<ReleasePayload, ReleaseRawPayload> {
   protected apiCarrier: APICarrier
   protected http: Cloud['http']
   protected options: ReleaseOptions
@@ -52,23 +61,27 @@ export class Release extends Entity<ReleasePaylod, ReleaseRawPayload> {
 
   public endpoint: string
 
-  public id?: ReleasePaylod['id']
-  public createdAt?: ReleasePaylod['createdAt']
-  public updatedAt?: ReleasePaylod['updatedAt']
-  public deleted?: ReleasePaylod['deleted']
-  public active?: ReleasePaylod['active']
-  public name?: ReleasePaylod['name']
-  public status?: ReleasePaylod['status']
-  public configuration?: ReleasePaylod['configuration']
-  public product?: ReleasePaylod['product']
-  public productName?: ReleasePaylod['productName']
-  public channel?: ReleasePaylod['channel']
-  public defaultDisplayName?: ReleasePaylod['defaultDisplayName']
+  public id?: ReleasePayload['id']
+  public createdAt?: ReleasePayload['createdAt']
+  public updatedAt?: ReleasePayload['updatedAt']
+  public deleted?: ReleasePayload['deleted']
+  public active?: ReleasePayload['active']
+  public name?: ReleasePayload['name']
+  public status?: ReleasePayload['status']
+  public allVersions?: ReleasePayload['allVersions']
+  public configuration?: ReleasePayload['configuration']
+  public product?: ReleasePayload['product']
+  public productName?: ReleasePayload['productName']
+  public channel?: ReleasePayload['channel']
+  public defaultDisplayName?: ReleasePayload['defaultDisplayName']
+  public organization?: ReleaseRawPayload['organization']
+  public pool?: ReleaseRawPayload['pool']
+  public release?: ReleaseRawPayload['release']
 
   constructor (options: ReleaseOptions) {
     super()
     this.apiCarrier = options.carrier
-    this.endpoint = 'api/v0/releases'
+    this.endpoint = 'api/v0/universes/releases'
     this.http = options.http
     this.options = options
     this.initialized = options.initialized ?? false
@@ -80,7 +93,6 @@ export class Release extends Entity<ReleasePaylod, ReleaseRawPayload> {
 
   protected deserialize (rawPayload: ReleaseRawPayload): Release {
     this.setRawPayload(rawPayload)
-
     this.id = rawPayload.id
     this.createdAt = rawPayload.created_at ? new Date(rawPayload.created_at) : undefined
     this.updatedAt = rawPayload.updated_at ? new Date(rawPayload.updated_at) : undefined
@@ -88,11 +100,15 @@ export class Release extends Entity<ReleasePaylod, ReleaseRawPayload> {
     this.active = rawPayload.active ?? true
     this.name = rawPayload.name
     this.status = rawPayload.status
+    this.allVersions = rawPayload.allVersions
     this.configuration = rawPayload.configuration
     this.product = rawPayload.product
     this.productName = rawPayload.product_name
     this.channel = rawPayload.channel
     this.defaultDisplayName = rawPayload.default_display_name
+    this.organization = rawPayload.organization
+    this.pool = rawPayload.pool
+    this.release = rawPayload.release
 
     return this
   }
@@ -110,11 +126,13 @@ export class Release extends Entity<ReleasePaylod, ReleaseRawPayload> {
       active: this.active ?? true,
       name: this.name,
       status: this.status,
+      allVersions: this.allVersions,
       configuration: this.configuration,
       product: this.product,
       product_name: this.productName,
-      channel: this.channel,
-      default_display_name: this.defaultDisplayName
+      organization: this.organization,
+      default_display_name: this.defaultDisplayName,
+      release: this.release
     }
   }
 
@@ -131,7 +149,7 @@ export class Release extends Entity<ReleasePaylod, ReleaseRawPayload> {
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Releases {
-  public static endpoint: string = 'api/v0/releases'
+  public static endpoint: string = 'api/v0/universes/releases'
 }
 
 export class ReleaseInitializationError extends BaseError {

--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -175,6 +175,26 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
     }
   }
 
+  public async deploy (): Promise<string> {
+    if (this.id === null || this.id === undefined) throw new TypeError('Universe.deploy requires universe id to be set.')
+    const deployEndpoint = `api/v0/universes/${this.id}/deploy/v2`
+    try {
+      const opts = {
+        method: 'PUT',
+        url: `${this.apiCarrier?.injectables?.base}/${deployEndpoint}`,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
+        responseType: 'json'
+      }
+
+      const res = await this.http?.getClient()(opts)
+      return res.statusText
+    } catch (err) {
+      throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError(undefined, { error: err }))
+    }
+  }
+
   universe (item: any, universe: any, http: Client): any {
     throw new Error('Method not implemented.')
   }
@@ -209,6 +229,13 @@ export class CloudUniversesFetchRemoteError extends BaseError {
   }
 }
 
+export class CloudUniverseDeployFromUniverseConfigRemoteError extends BaseError {
+  public name = 'CloudUniversePatchDeployFromReleaseRemoteError'
+  constructor (public message: string = 'Could alter deployment unexpectedly.', properties?: any) {
+    super(message, properties)
+    Object.setPrototypeOf(this, CloudUniversePatchDeployFromReleaseRemoteError.prototype)
+  }
+}
 export class CloudUniversePatchDeployFromReleaseRemoteError extends BaseError {
   public name = 'CloudUniversePatchDeployFromReleaseRemoteError'
   constructor (public message: string = 'Could alter deployment unexpectedly.', properties?: any) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,12 @@
       ]
     }
   },
+  "linked-module-name": [
+    "node_modules@heycharles/browser-sdk/dist"
+  ],
+  "linked-module-name/*": [
+    "node_modules/@heycharles/browser-sdk/dist/*"
+  ],
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"


### PR DESCRIPTION
update defintion of release entity to include all required fields for versioned universe deployment
(fields for configuration of a given universe and also include allVersions in payload) and add
linked-module-name tsconfig option to allow "npm link @heycharles/browser-sdk" in other projects to
build against local browser-sdk changes without needing to copy project into node_modules