### PR TITLE
[TECH-1676] feat(message-templates): Fetch templates of Generic kind only

### DIFF
--- a/src/universe/index.ts
+++ b/src/universe/index.ts
@@ -1534,7 +1534,12 @@ export class Universe extends APICarrier {
 
   public async messageTemplates (): Promise<messageTemplate.MessageTemplate[] | undefined> {
     try {
-      const res = await this.http.getClient().get(`${this.universeBase}/${messageTemplate.MessageTemplates.endpoint}`)
+      const res = await this.http.getClient().get(`${this.universeBase}/${messageTemplate.MessageTemplates.endpoint}`, {
+        // Fetch only none-FlowBuilder templates (That are of kind "AutomationEngine")
+        params: {
+          kind: ['Generic', 'ProductGeneral', 'ProductDetail']
+        }
+      })
       const resources = res.data.data as messageTemplate.MessageTemplateRawPayload[]
 
       return resources.map((resource: messageTemplate.MessageTemplateRawPayload) => {


### PR DESCRIPTION
- [x] Tested Manually  (Templates returned when type is `Generic`, `ProductGeneral`, or `ProductDetail`. Not returned when type is `AutomationEngine`)
- [x] Verified with flowbuilder team that they do not use the browser-sdk fetching.
- [x] Verified with PO that there are no use cases where a client would require the `AutomationEngine` templates at the meantime.