### PR TITLE
feat(universes/universes_pools): add update method for fetching lates…

### DIFF
--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -45,6 +45,11 @@ export interface UniverseDeployStatus {
   readonly jobStatus: string | null
 }
 
+export interface UniversesUpdateAllResponse {
+  readonly id: UniverseDeployStatus
+}
+
+
 /**
  * Manage CloudUniverses.
  *
@@ -117,6 +122,26 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
       organization: this.organization,
       status: this.status,
       release: this.release
+    }
+  }
+
+  public async updateAll (): Promise<UniversesUpdateAllResponse[]> {
+    try {
+      const updateAllEndpoint = `${this.endpoint}/deploy/status`
+      const opts = {
+        method: 'GET',
+        url: `${this.apiCarrier?.injectables?.base}/${updateAllEndpoint}`,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
+        responseType: 'json'
+      }
+
+      const res = await this.http?.getClient()(opts)
+      const resource = res.data.data as UniversesUpdateAllResponse[]
+      return resource
+    } catch (err) {
+      throw this.handleError(new UniversesUpdateAllError())
     }
   }
 
@@ -274,5 +299,12 @@ export class CloudUniversePatchDeployFromReleaseRemoteError extends BaseError {
   constructor (public message: string = 'Could alter deployment unexpectedly.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, CloudUniversePatchDeployFromReleaseRemoteError.prototype)
+  }
+}
+export class UniversesUpdateAllError extends BaseError {
+  public name = 'UniversesUpdateAllError'
+  constructor (public message: string = 'Could not update universes.', properties?: any) {
+    super(message, properties)
+    Object.setPrototypeOf(this, UniversesUpdateAllError.prototype)
   }
 }

--- a/src/cloud/entities/universes-pool/universes-pool.ts
+++ b/src/cloud/entities/universes-pool/universes-pool.ts
@@ -33,6 +33,11 @@ export interface UniversePoolDeployStatus {
   readonly deployStatus: string | null
   readonly jobStatus: string | null
 }
+
+export interface UniversesPoolUpdateAllResponse {
+  readonly id: UniversePoolDeployStatus
+}
+
 /**
  * Manage organizations.
  *
@@ -97,6 +102,26 @@ export class UniversesPool extends Entity<UniversesPoolPayload, UniversesPoolRaw
       name: this.name,
       status: this.status,
       configuration: this.configuration
+    }
+  }
+
+  public async updateAll (): Promise<UniversesPoolUpdateAllResponse[]> {
+    try {
+      const updateAllEndpoint = `${this.endpoint}/deploy/status`
+      const opts = {
+        method: 'GET',
+        url: `${this.apiCarrier?.injectables?.base}/${updateAllEndpoint}`,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
+        responseType: 'json'
+      }
+
+      const res = await this.http?.getClient()(opts)
+      const resource = res.data.data as UniversesPoolUpdateAllResponse[]
+      return resource
+    } catch (err) {
+      throw this.handleError(new UniversesPoolsUpdateAllError())
     }
   }
 
@@ -194,5 +219,13 @@ export class UniversesPoolsFetchRemoteError extends BaseError {
   constructor (public message: string = 'Could not get universes pools.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, UniversesPoolsFetchRemoteError.prototype)
+  }
+}
+
+export class UniversesPoolsUpdateAllError extends BaseError {
+  public name = 'UniversesPoolsUpdateAllError'
+  constructor (public message: string = 'Could not update pools.', properties?: any) {
+    super(message, properties)
+    Object.setPrototypeOf(this, UniversesPoolsUpdateAllError.prototype)
   }
 }


### PR DESCRIPTION
…t deployment status

update all method can be called on page refresh to update the statuses of all universes and pools
loaded. It is not automatically included in the getAll handler since this would add excessive
latency for GET requests, SQLAdmin and CloudBuild requests to what would otherwise be a database
lookup. i.e. call updateAll and then refresh, as needed.