### PR TITLE
chore(message-subscriptions): Remove message subscription duplication

### DIFF
--- a/src/entities/message-subscription/message-subscription.ts
+++ b/src/entities/message-subscription/message-subscription.ts
@@ -274,30 +274,6 @@ export class MessageSubscription extends UniverseEntity<MessageSubscriptionPaylo
   }
 
   /**
-   * Create a copy of the message subscription
-   */
-  public async duplicate (overridePayload: MessageSubscriptionRawPayload = {}): Promise<MessageSubscription> {
-    try {
-      const duplicatePayload = {
-        ...this.serialize(),
-        id: undefined,
-        created_at: undefined,
-        updated_at: undefined,
-        deleted: undefined,
-        active: undefined,
-        ...overridePayload
-      }
-
-      const subscription = MessageSubscription.create(duplicatePayload, this.universe, this.http)
-      await subscription.post()
-
-      return subscription
-    } catch (err) {
-      throw this.handleError(new MessageSubscriptionDuplicateError(undefined, { error: err }))
-    }
-  }
-
-  /**
  * Get a list of all message subscription subscriber instances
  */
   public async subscribers (options?: EntityFetchOptions): Promise<MessageSubscriptionInstanceRawPayload[]> {


### PR DESCRIPTION
- Removes message subscription `.duplicate` function in favour of introduced functionality to clone using base entity `.clone`

Requirements for merging:

1. https://github.com/c-commerce/charles-client-api/pull/847
2. https://github.com/c-commerce/charles-agent-ui/pull/1484