### PR TITLE
feat(universe.ts): moved operatorUniverses to cloud index

### DIFF
--- a/src/cloud/entities/universe/index.ts
+++ b/src/cloud/entities/universe/index.ts
@@ -3,12 +3,18 @@ import {
   CloudUniverse,
   CloudUniverses,
   CloudUniverseRawPayload,
-  CloudUniversesFetchRemoteError
+  CloudUniversesFetchRemoteError,
+  OperatorUniverse,
+  OperatorUniverseResponse,
+  OperatorUniverseError
 } from './universe'
 
 export {
   CloudUniverse,
   CloudUniverseRawPayload,
   CloudUniverses,
-  CloudUniversesFetchRemoteError
+  CloudUniversesFetchRemoteError,
+  OperatorUniverse,
+  OperatorUniverseResponse,
+  OperatorUniverseError
 }

--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -48,7 +48,10 @@ export type DeployVersionResponse = SingleDeployVersionResponse | [SingleDeployV
 
 export type OperatorUniverse = {
   readonly id: string
-  readonly name?: string
+  readonly name: string,
+  readonly pool: string,
+  readonly organization: string,
+  readonly createdAt: string,
   readonly configuration: {
     readonly versions: {
       readonly agent_ui: string
@@ -56,10 +59,12 @@ export type OperatorUniverse = {
     }
   }
   readonly privileges: [UniverseIam]
-  readonly logLevel?: LogLevel
-  readonly size?: 'small' | 'large'
-  readonly userHasPermissions?: boolean
-  readonly isLive?: boolean
+  readonly logLevel: LogLevel
+  readonly size: 'small' | 'large'
+  readonly userHasPermissions: boolean,
+  readonly status: string,
+  readonly applied: boolean,
+  readonly isLive: boolean
 }
 
 export type OperatorUniverseResponse = OperatorUniverse | [OperatorUniverse]

--- a/src/cloud/index.ts
+++ b/src/cloud/index.ts
@@ -440,6 +440,16 @@ export class Cloud extends APICarrier {
     }
   }
 
+  public async operatorUniverses (): Promise<universe.OperatorUniverseResponse> {
+    try {
+      const res = await this.http.getClient().get(`${this.cloudBase}/api/v0/universes/operator`)
+
+      return res.data?.data
+    } catch (err) {
+      throw new universe.OperatorUniverseError()
+    }
+  }
+
   public async healthz (): Promise<{ message: string } | undefined> {
     try {
       const res = await this.http.getClient().get(`${this.cloudBase}/api/healthz`)


### PR DESCRIPTION
Custom table component on cloud-ui takes a `resource` string to fetch the data to be displayed. This resource string is used as the function name on browser-sdk. Had to move a copy of the `operatorUniverses` function to the `cloud.ts` index file to avoid having to change a lot of code on cloud-ui