### PR TITLE
feat(revenue-metrics-handlers): added revenueMetrics sdk fn for homep…

### DIFF
--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -136,3 +136,38 @@ export interface SubscriberMetrics {
   total_subscribers: number
   date: string
 }
+
+export interface RevenueFields {
+  distinct_person_count?: number
+  orders_count?: number
+  conversation_business_count?: number
+  conversation_marketing_count?: number
+  conversation_utility_count?: number
+  journeys_count?: number
+  journeys_revenue_gross_total?: number
+  journeys_revenue_net_total?: number
+  campaigns_count?: number
+  campaigns_revenue_net_total?: number
+  campaigns_revenue_gross_total?: number
+  per_conversation_mean?: number
+  revenue_gross_total?: number
+  revenue_net_total?: number
+}
+
+export interface RevenueMetricsValue extends RevenueFields {
+  timeframe_start: string // DateTime ISO string
+  timeframe_end: string // DateTime ISO string
+  label: string
+}
+
+export interface RevenueMetrics {
+  created_at: string
+  metric: {
+    job: AnalyticsReportJob
+    query: {
+      start: string
+      end: string
+    }
+  }
+  values: RevenueMetricsValue[]
+}

--- a/src/universe/analytics.ts
+++ b/src/universe/analytics.ts
@@ -11,7 +11,9 @@ import {
   MessageBrokerConversationsAnalyticsResponse,
   MessageBrokerMessagesCountAnalyticsOptions,
   MessageBrokerMessagesCountAnalyticsResponse,
-  SubscriberMetrics
+  SubscriberMetrics,
+  RevenueMetrics,
+  RevenueFields
 } from '../analytics/analytics'
 
 export interface UniverseAnalyticsOptions {
@@ -28,6 +30,15 @@ export interface UniverseAnalyticsEventsOptions {
   datepart?: string
 }
 
+export interface UniverseRevenueMetricsOptions {
+  groupBy?: 'day' | 'week' | 'month' | 'year' | 'version'
+  version: 'last_touch' | 'testing'
+  // The following fields are date iso strings
+  start: string
+  end: string
+  fields?: Array<keyof RevenueFields>
+}
+
 export interface UniverseAnalytics {
   orders: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
   revenues: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
@@ -42,6 +53,7 @@ export interface UniverseAnalytics {
   messageBrokerConversations: (options?: MessageBrokerConversationsAnalyticsOptions) => Promise<MessageBrokerConversationsAnalyticsResponse | undefined>
   messageBrokerMessagesCount: (options?: MessageBrokerMessagesCountAnalyticsOptions) => Promise<MessageBrokerMessagesCountAnalyticsResponse | undefined>
   subscriberMetrics: () => Promise<SubscriberMetrics | undefined>
+  revenueMetrics: (options: UniverseRevenueMetricsOptions) => Promise<RevenueMetrics | undefined>
 }
 
 export function analytics (this: Universe): UniverseAnalytics {
@@ -99,6 +111,9 @@ export function analytics (this: Universe): UniverseAnalytics {
     },
     subscriberMetrics: async (options?: UniverseAnalyticsOptions): Promise<SubscriberMetrics> => {
       return await makeAnalyticsRequest<SubscriberMetrics, undefined>('/universe/subscriptions')
+    },
+    revenueMetrics: async (options: UniverseRevenueMetricsOptions): Promise<RevenueMetrics> => {
+      return await makeAnalyticsRequest<RevenueMetrics, UniverseRevenueMetricsOptions>('/attribution', options)
     }
   }
 }


### PR DESCRIPTION
…age & chart

Required for: 
https://app.clickup.com/t/24327122/TECH-9315 &
https://app.clickup.com/t/24327122/TECH-9393

requires: 
https://github.com/c-commerce/charles-client-api/pull/2192