### PR TITLE
feat(revenue-metrics): add grouping and filtering by fields

### DIFF
--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -4,6 +4,7 @@ export const ANALYTICS_ENDPOINT = 'api/v0/analytics/reports'
 
 export class AnalyticsFetchRemoteError extends BaseError {
   public name = 'AnalyticsFetchRemoteError'
+
   constructor (public message: string = 'Could not get analytics.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AnalyticsFetchRemoteError.prototype)
@@ -144,21 +145,25 @@ export interface RevenueFields {
   conversation_marketing_count?: number
   conversation_utility_count?: number
   journeys_count?: number
-  journeys_revenue_gross_total?: number
   journeys_revenue_net_total?: number
+  journeys_revenue_gross_total?: number
+  journeys_refunds_gross_total?: number
   campaigns_count?: number
   campaigns_revenue_net_total?: number
   campaigns_revenue_gross_total?: number
-  per_conversation_mean?: number
-  revenue_gross_total?: number
+  campaigns_refunds_gross_total?: number
   revenue_net_total?: number
+  revenue_gross_total?: number
+  refunds_gross_total?: number
+  per_conversation_mean?: number
+  currency?: string
 }
 
 export type RevenueVersions =
-  'last_touch' |
-  'testing' |
-  'coupon_code_unstitched' |
-  'coupon_code_all'
+  | 'last_touch'
+  | 'testing'
+  | 'coupon_code_unstitched'
+  | 'coupon_code_all'
 
 export interface RevenueMetricsValue extends RevenueFields {
   timeframe_start: string // DateTime ISO string

--- a/src/universe/analytics.ts
+++ b/src/universe/analytics.ts
@@ -4,17 +4,17 @@ import {
   ANALYTICS_ENDPOINT,
   AnalyticsFetchRemoteError,
   AnalyticsReport,
-  SubscriptionAnalyticsResponse,
-  SubscriberBaseAnalyticsResponse,
   FlowsTriggeredAnalyticsResponse,
   MessageBrokerConversationsAnalyticsOptions,
   MessageBrokerConversationsAnalyticsResponse,
   MessageBrokerMessagesCountAnalyticsOptions,
   MessageBrokerMessagesCountAnalyticsResponse,
-  SubscriberMetrics,
-  RevenueMetrics,
   RevenueFields,
+  RevenueMetrics,
   RevenueVersions,
+  SubscriberBaseAnalyticsResponse,
+  SubscriberMetrics,
+  SubscriptionAnalyticsResponse,
   SyncedContactsResponse
 } from '../analytics/analytics'
 
@@ -32,35 +32,126 @@ export interface UniverseAnalyticsEventsOptions {
   datepart?: string
 }
 
+/**
+ * When you want to filter the revenue data, you can use these filters, which are fields within the revenue data!
+ */
+export type UniverseRevenueDataFilters =
+  | 'origin'
+  | 'campaign_id'
+  | 'flow_id'
+  | 'target'
+  | 'order_id'
+  | 'person_id'
+
 export interface UniverseRevenueMetricsOptions {
-  groupBy?: 'day' | 'week' | 'month' | 'year' | 'version'
-  version?: RevenueVersions | RevenueVersions[]
-  // The following fields are date iso strings
-  start: string
-  end: string
+  /**
+   * The start date of the timeframe in UTC time zone!
+   */
+  start: Date | string
+
+  /**
+   * The end date of the timeframe in UTC time zone!
+   */
+  end: Date | string
+
+  /**
+   * When provided you can limit the fields returned in the response!
+   */
   fields?: Array<keyof RevenueFields>
+
+  /**
+   * The groping type for the revenue data, where:
+   * - `day`, `week`, `month`, `year` are time based groupings
+   * - `version` will group by the various cartesian products of the attribution models
+   * - `origin` will group by the various origins of the revenue such a campaign_id and flow_id
+   * - `origin_type` will group by the various origin types of the revenue such as campaigns and flows
+   * - `target` will group by the various targets of the revenue such as order_id
+   * - `target_type` will group by the various target types of the revenue such as order
+   *
+   * By default, it will group by `day`, `week`, or `month` depending on the timeframe:
+   * - more than 90 days -> `month`
+   * - more than 30 days -> `week`
+   * - otherwise -> `day`
+   */
+  groupBy?:
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'year'
+  | 'version'
+  | 'origin'
+  | 'origin_type'
+  | 'target'
+  | 'target_type'
+
+  /**
+   * When you want to explicitly select the attribution models, this is the field to use.
+   * By default, it will return the currently active attribution models.
+   *
+   * @deprecated Use `versions` instead!
+   */
+  version?: RevenueVersions[] | RevenueVersions
+
+  /**
+   * When you want to explicitly select the attribution models, this is the field to use.
+   * By default, it will return the currently active attribution models.
+   */
+  versions?: RevenueVersions[]
+
+  /**
+   * Data filters to apply before aggregations, note that the `start` and `end` dates are always applied!
+   */
+  filters: Record<UniverseRevenueDataFilters, string[] | string>
+
+  /**
+   * Configure the precision digits of the aggregated values, by default it will be 2 digits!
+   */
+  precision?: number
+
+  /**
+   * The timezone to convert the results to, by default it will be UTC!
+   *
+   * @future This is not implemented yet!
+   */
+  tz?: string
 }
 
 export interface UniverseAnalytics {
   orders: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
   revenues: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
   xau: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
-  subscriberBaseEvents: (options?: UniverseAnalyticsEventsOptions) => Promise<SubscriberBaseAnalyticsResponse | undefined>
-  subscriptionEventsBySubscriptionId: (subscriptionId: string, options?: UniverseAnalyticsEventsOptions) => Promise<SubscriptionAnalyticsResponse | undefined>
-  subscriptionEvents: (options?: UniverseAnalyticsEventsOptions) => Promise<SubscriptionAnalyticsResponse | undefined>
+  subscriberBaseEvents: (
+    options?: UniverseAnalyticsEventsOptions
+  ) => Promise<SubscriberBaseAnalyticsResponse | undefined>
+  subscriptionEventsBySubscriptionId: (
+    subscriptionId: string,
+    options?: UniverseAnalyticsEventsOptions
+  ) => Promise<SubscriptionAnalyticsResponse | undefined>
+  subscriptionEvents: (
+    options?: UniverseAnalyticsEventsOptions
+  ) => Promise<SubscriptionAnalyticsResponse | undefined>
   feedOpenedClosed: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
   feedConversion: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
-  peopleMessagingChannelParticipationDistribution: (options?: UniverseAnalyticsOptions) => Promise<AnalyticsReport[] | undefined>
+  peopleMessagingChannelParticipationDistribution: (
+    options?: UniverseAnalyticsOptions
+  ) => Promise<AnalyticsReport[] | undefined>
   flowsTriggered: () => Promise<FlowsTriggeredAnalyticsResponse | undefined>
-  messageBrokerConversations: (options?: MessageBrokerConversationsAnalyticsOptions) => Promise<MessageBrokerConversationsAnalyticsResponse | undefined>
-  messageBrokerMessagesCount: (options?: MessageBrokerMessagesCountAnalyticsOptions) => Promise<MessageBrokerMessagesCountAnalyticsResponse | undefined>
+  messageBrokerConversations: (
+    options?: MessageBrokerConversationsAnalyticsOptions
+  ) => Promise<MessageBrokerConversationsAnalyticsResponse | undefined>
+  messageBrokerMessagesCount: (
+    options?: MessageBrokerMessagesCountAnalyticsOptions
+  ) => Promise<MessageBrokerMessagesCountAnalyticsResponse | undefined>
   subscriberMetrics: () => Promise<SubscriberMetrics | undefined>
   revenueMetrics: (options: UniverseRevenueMetricsOptions) => Promise<RevenueMetrics | undefined>
   syncedContacts: () => Promise<SyncedContactsResponse | undefined>
 }
 
 export function analytics (this: Universe): UniverseAnalytics {
-  const makeAnalyticsRequest = async <TResult, TOptions>(endpointSlug: string, options?: TOptions): Promise<TResult> => {
+  const makeAnalyticsRequest = async <TResult, TOptions>(
+    endpointSlug: string,
+    options?: TOptions
+  ): Promise<TResult> => {
     try {
       const opts = {
         method: 'GET',
@@ -77,46 +168,97 @@ export function analytics (this: Universe): UniverseAnalytics {
 
   return {
     orders: async (options?: UniverseAnalyticsOptions): Promise<AnalyticsReport[]> => {
-      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>('/commerce/orders/distribution/count', options)
+      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>(
+        '/commerce/orders/distribution/count',
+        options
+      )
     },
     revenues: async (options?: UniverseAnalyticsOptions): Promise<AnalyticsReport[]> => {
-      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>('/commerce/revenues/distribution', options)
+      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>(
+        '/commerce/revenues/distribution',
+        options
+      )
     },
     xau: async (options?: UniverseAnalyticsOptions): Promise<AnalyticsReport[]> => {
-      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>('/messages/xau/count', options)
+      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>(
+        '/messages/xau/count',
+        options
+      )
     },
-    subscriberBaseEvents: async (options?: UniverseAnalyticsEventsOptions): Promise<SubscriberBaseAnalyticsResponse | undefined> => {
-      return await makeAnalyticsRequest<SubscriberBaseAnalyticsResponse, UniverseAnalyticsEventsOptions>('/events/subscriptions/subscriber_base', options)
+    subscriberBaseEvents: async (
+      options?: UniverseAnalyticsEventsOptions
+    ): Promise<SubscriberBaseAnalyticsResponse | undefined> => {
+      return await makeAnalyticsRequest<
+      SubscriberBaseAnalyticsResponse,
+      UniverseAnalyticsEventsOptions
+      >('/events/subscriptions/subscriber_base', options)
     },
-    subscriptionEventsBySubscriptionId: async (subscriptionId: string, options?: UniverseAnalyticsEventsOptions): Promise<SubscriptionAnalyticsResponse | undefined> => {
-      return await makeAnalyticsRequest<SubscriptionAnalyticsResponse, UniverseAnalyticsEventsOptions>(`/events/subscriptions/${subscriptionId}`, options)
+    subscriptionEventsBySubscriptionId: async (
+      subscriptionId: string,
+      options?: UniverseAnalyticsEventsOptions
+    ): Promise<SubscriptionAnalyticsResponse | undefined> => {
+      return await makeAnalyticsRequest<
+      SubscriptionAnalyticsResponse,
+      UniverseAnalyticsEventsOptions
+      >(`/events/subscriptions/${subscriptionId}`, options)
     },
-    subscriptionEvents: async (options?: UniverseAnalyticsEventsOptions): Promise<SubscriptionAnalyticsResponse | undefined> => {
-      return await makeAnalyticsRequest<SubscriptionAnalyticsResponse, UniverseAnalyticsEventsOptions>('/events/subscriptions', options)
+    subscriptionEvents: async (
+      options?: UniverseAnalyticsEventsOptions
+    ): Promise<SubscriptionAnalyticsResponse | undefined> => {
+      return await makeAnalyticsRequest<
+      SubscriptionAnalyticsResponse,
+      UniverseAnalyticsEventsOptions
+      >('/events/subscriptions', options)
     },
-    peopleMessagingChannelParticipationDistribution: async (options?: UniverseAnalyticsOptions): Promise<AnalyticsReport[]> => {
-      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>('/people/channel_participation/distribution', options)
+    peopleMessagingChannelParticipationDistribution: async (
+      options?: UniverseAnalyticsOptions
+    ): Promise<AnalyticsReport[]> => {
+      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>(
+        '/people/channel_participation/distribution',
+        options
+      )
     },
     feedOpenedClosed: async (options?: UniverseAnalyticsOptions): Promise<AnalyticsReport[]> => {
-      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>('/feeds/open_close/distribution/count', options)
+      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>(
+        '/feeds/open_close/distribution/count',
+        options
+      )
     },
     feedConversion: async (options?: UniverseAnalyticsOptions): Promise<AnalyticsReport[]> => {
-      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>('/feeds/conversion/counts', options)
+      return await makeAnalyticsRequest<AnalyticsReport[], UniverseAnalyticsOptions>(
+        '/feeds/conversion/counts',
+        options
+      )
     },
     flowsTriggered: async (): Promise<FlowsTriggeredAnalyticsResponse> => {
-      return await makeAnalyticsRequest<FlowsTriggeredAnalyticsResponse, undefined>('/flows_triggered')
+      return await makeAnalyticsRequest<FlowsTriggeredAnalyticsResponse, undefined>(
+        '/flows_triggered'
+      )
     },
-    messageBrokerConversations: async (options?: MessageBrokerConversationsAnalyticsOptions): Promise<MessageBrokerConversationsAnalyticsResponse> => {
-      return await makeAnalyticsRequest<MessageBrokerConversationsAnalyticsResponse, MessageBrokerConversationsAnalyticsOptions>('/message_broker/conversations', options)
+    messageBrokerConversations: async (
+      options?: MessageBrokerConversationsAnalyticsOptions
+    ): Promise<MessageBrokerConversationsAnalyticsResponse> => {
+      return await makeAnalyticsRequest<
+      MessageBrokerConversationsAnalyticsResponse,
+      MessageBrokerConversationsAnalyticsOptions
+      >('/message_broker/conversations', options)
     },
-    messageBrokerMessagesCount: async (options?: MessageBrokerMessagesCountAnalyticsOptions): Promise<MessageBrokerMessagesCountAnalyticsResponse> => {
-      return await makeAnalyticsRequest<MessageBrokerMessagesCountAnalyticsResponse, MessageBrokerMessagesCountAnalyticsOptions>('/message_broker/messages_count', options)
+    messageBrokerMessagesCount: async (
+      options?: MessageBrokerMessagesCountAnalyticsOptions
+    ): Promise<MessageBrokerMessagesCountAnalyticsResponse> => {
+      return await makeAnalyticsRequest<
+      MessageBrokerMessagesCountAnalyticsResponse,
+      MessageBrokerMessagesCountAnalyticsOptions
+      >('/message_broker/messages_count', options)
     },
     subscriberMetrics: async (options?: UniverseAnalyticsOptions): Promise<SubscriberMetrics> => {
       return await makeAnalyticsRequest<SubscriberMetrics, undefined>('/universe/subscriptions')
     },
     revenueMetrics: async (options: UniverseRevenueMetricsOptions): Promise<RevenueMetrics> => {
-      return await makeAnalyticsRequest<RevenueMetrics, UniverseRevenueMetricsOptions>('/attribution', options)
+      return await makeAnalyticsRequest<RevenueMetrics, UniverseRevenueMetricsOptions>(
+        '/attribution',
+        options
+      )
     },
     syncedContacts: async (): Promise<SyncedContactsResponse> => {
       return await makeAnalyticsRequest<SyncedContactsResponse, undefined>('/synced_contacts')


### PR DESCRIPTION
Adding support for grouping Revenue Metrics by their origin with some overdue clean-up of the used views. Additionally, multiple origins can be specified, and grouping and filtering by target is also available.

Refs: TECH-10487

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

## Relations

- Implements https://github.com/c-commerce/charles-client-api/pull/2351
