### PR TITLE
fix: remove default timeout

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -53,7 +53,7 @@ export class Client {
     this.axiosInstance = axios.create({
       withCredentials: this.options.withCredentials ?? undefined,
       // baseURL: options.base || 'https://api.hello-charles.com',
-      timeout: options.timeout ?? 10000,
+      timeout: options.timeout,
       headers: {
         ...options.headers,
         ...defaultHeaders

--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -41,8 +41,8 @@ export interface DeployReleasePayload {
     readonly name: string
     readonly author: string
     readonly 'client-api'?: string
-  	readonly 'agent-ui'?: string
-  	readonly 'cloudsql-proxy'?: string
+    readonly 'agent-ui'?: string
+    readonly 'cloudsql-proxy'?: string
   }
 }
 

--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -15,12 +15,12 @@ type LogLevel = 'none' | 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
 type ChurnLevel = 'None' | 'Light' | 'Medium' | 'Full'
 
 export interface DeployOperatorOptions {
-  readonly size: 'small' | 'large',
+  readonly size: 'small' | 'large'
   readonly logLevel: LogLevel
 }
 
 export interface PatchOperatorOptions {
-  readonly size?: 'small' | 'large',
+  readonly size?: 'small' | 'large'
   readonly logLevel?: LogLevel
 }
 
@@ -36,14 +36,14 @@ export interface DeployOptions {
 
 export interface DeployReleasePayload {
   readonly universe: string | [string]
-	readonly release: {
-		readonly id: string
-		readonly name: string
-		readonly author: string
-		readonly 'client-api'?: string
+  readonly release: {
+    readonly id: string
+    readonly name: string
+    readonly author: string
+    readonly 'client-api'?: string
   	readonly 'agent-ui'?: string
   	readonly 'cloudsql-proxy'?: string
-	}
+  }
 }
 
 export interface SingleDeployReleaseResponse {
@@ -52,12 +52,12 @@ export interface SingleDeployReleaseResponse {
 
 export type DeployReleaseResponse = SingleDeployReleaseResponse | [SingleDeployReleaseResponse]
 
-export type OperatorUniverse = {
+export interface OperatorUniverse {
   readonly id: string
-  readonly name: string,
-  readonly pool: string,
-  readonly organization: string,
-  readonly createdAt: string,
+  readonly name: string
+  readonly pool: string
+  readonly organization: string
+  readonly createdAt: string
   readonly configuration: {
     readonly versions: {
       readonly agent_ui: string
@@ -67,50 +67,50 @@ export type OperatorUniverse = {
   readonly privileges: [UniverseIam]
   readonly logLevel: LogLevel
   readonly size: 'small' | 'large'
-  readonly userHasPermissions: boolean,
-  readonly status: string,
-  readonly applied: boolean,
+  readonly userHasPermissions: boolean
+  readonly status: string
+  readonly applied: boolean
   readonly isLive: boolean
 }
 
 export type OperatorUniverseResponse = OperatorUniverse | [OperatorUniverse]
 
-export type ReleaseHistoryResponse = {
-	readonly id: string
-	readonly universe: string
-	readonly deployed_at: string
-	readonly deployed_by: string
-	readonly release: string
-	readonly versions: {
-		readonly name: string
-		readonly product: string
-	}[]
+export interface ReleaseHistoryResponse {
+  readonly id: string
+  readonly universe: string
+  readonly deployed_at: string
+  readonly deployed_by: string
+  readonly release: string
+  readonly versions: Array<{
+    readonly name: string
+    readonly product: string
+  }>
 }
 
-export type UniverseIam = {
+export interface UniverseIam {
   readonly member: string
   readonly resource: string
   readonly role: string
   readonly expires?: string
 }
 
-export type UniverseIamUser = {
+export interface UniverseIamUser {
   readonly email: string
   readonly type: string
 }
 
-export type UniverseIamPrivilege = {
+export interface UniverseIamPrivilege {
   readonly resource: string
   readonly role: string
   readonly expiresInDays?: Number
 }
 
-export type UniversePutIamPayload = {
+export interface UniversePutIamPayload {
   readonly users: [UniverseIamUser]
   readonly privileges: [UniverseIamPrivilege]
 }
 
-export type UniverseDeleteIamPayload = {
+export interface UniverseDeleteIamPayload {
   readonly user: UniverseIamUser
   readonly privilege: UniverseIamPrivilege
 }
@@ -515,7 +515,7 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
         headers: {
           'Content-Type': 'application/json; charset=utf-8'
         },
-        responseType: 'json',
+        responseType: 'json'
       }
       const res = await this.http?.getClient()(opts)
       const { status, msg, data } = res.data
@@ -538,7 +538,7 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
         headers: {
           'Content-Type': 'application/json; charset=utf-8'
         },
-        responseType: 'json',
+        responseType: 'json'
       }
       const res = await this.http?.getClient()(opts)
       const { status, msg, data } = res.data
@@ -552,30 +552,30 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
     }
   }
 
-	public async patchChurn (churnLevel: ChurnLevel): Promise<void> {
-		if (this.id === null || this.id === undefined) throw new TypeError('Universe.patchChurn requires universe id to be set.')
-		const endpoint = `api/v0/universes/${this.id}/churn`
-		try {
-			const opts = {
-				method: 'POST',
-				url: `${this.apiCarrier?.injectables?.base}/${endpoint}`,
-				headers: {
-					'Content-Type': 'application/json; charset=utf-8'
-				},
-				responseType: 'json',
-				data: {
-					churnLevel
-				}
-			}
-			const res = await this.http?.getClient()(opts)
-			const { status } = res.data
-			if (status !== 200) {
-				throw this.handleError(new PatchChurnError())
-			}
-		} catch (err) {
-			throw this.handleError(new PatchChurnError())
-		}
-	}
+  public async patchChurn (churnLevel: ChurnLevel): Promise<void> {
+    if (this.id === null || this.id === undefined) throw new TypeError('Universe.patchChurn requires universe id to be set.')
+    const endpoint = `api/v0/universes/${this.id}/churn`
+    try {
+      const opts = {
+        method: 'POST',
+        url: `${this.apiCarrier?.injectables?.base}/${endpoint}`,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
+        responseType: 'json',
+        data: {
+          churnLevel
+        }
+      }
+      const res = await this.http?.getClient()(opts)
+      const { status } = res.data
+      if (status !== 200) {
+        throw this.handleError(new PatchChurnError())
+      }
+    } catch (err) {
+      throw this.handleError(new PatchChurnError())
+    }
+  }
 
   public async patchOperatorOptions (id: string, payload: PatchOperatorOptions): Promise<void> {
     const endpoint = `api/v0/universes/operator/${id}/options`
@@ -599,8 +599,8 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
     }
   }
 
-	public async fetchReleaseHistory (): Promise<ReleaseHistoryResponse[]> {
-		if (this.id === null || this.id === undefined) throw new TypeError('Universe.getReleaseHistory requires universe id to be set.')
+  public async fetchReleaseHistory (): Promise<ReleaseHistoryResponse[]> {
+    if (this.id === null || this.id === undefined) throw new TypeError('Universe.getReleaseHistory requires universe id to be set.')
     const endpoint = `api/v0/universes/release-history/${this.id}`
     try {
       const opts = {
@@ -650,7 +650,7 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
   public async putIamPrivileges (payload: UniversePutIamPayload): Promise<UniverseIamResponse> {
     if (this.id === null || this.id === undefined) throw new TypeError('universe.putIamPrivileges() requires universe id to be set.')
     const endpoint = `api/v0/universes/iam/${this.id}`
-    
+
     try {
       const opts = {
         method: 'PUT',

--- a/src/entities/_base/index.ts
+++ b/src/entities/_base/index.ts
@@ -584,7 +584,6 @@ export abstract class EntitiesList<Entity, RawPayload> extends Readable {
   protected async _exportCsv (options?: EntitiesListExportCsvOptions): Promise<Blob> {
     const opts = {
       method: 'GET',
-      timeout: 60000,
       url: `${this.apiCarrier?.injectables?.base}/${this.endpoint}${options?.query ? qs.stringify(options.query, { addQueryPrefix: true }) : ''}`,
       headers: {
         Accept: 'text/csv'
@@ -621,7 +620,7 @@ export abstract class EntitiesList<Entity, RawPayload> extends Readable {
           'Content-Type': 'application/json; charset=utf-8'
         },
         data: undefined,
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout,
         responseType: 'json'
       }
 
@@ -654,7 +653,7 @@ export abstract class EntitiesList<Entity, RawPayload> extends Readable {
           'Content-Type': 'application/json; charset=utf-8'
         },
         data: undefined,
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout,
         responseType: 'json'
       }
 
@@ -694,7 +693,7 @@ export abstract class EntitiesList<Entity, RawPayload> extends Readable {
           'Content-Type': 'application/json; charset=utf-8'
         },
         data: payload,
-        timeout: options?.timeout ?? 30000,
+        timeout: options?.timeout,
         responseType: 'json'
       }
 

--- a/src/entities/asset/asset.ts
+++ b/src/entities/asset/asset.ts
@@ -160,7 +160,6 @@ export class Asset extends UniverseEntity<AssetPayload, AssetRawPayload> {
       }
 
       const opts = {
-        timeout: 60000,
         headers: {
           'Content-Type': 'multipart/form-data'
         }
@@ -244,7 +243,7 @@ export class Assets {
       }
 
       const opts = {
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout,
         headers: {
           'Content-Type': 'multipart/form-data'
         }

--- a/src/entities/async-exports/async-export.ts
+++ b/src/entities/async-exports/async-export.ts
@@ -49,7 +49,7 @@ export interface AsyncExportPayload {
 }
 
 export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportRawPayload> {
-  public get entityName (): string {
+  public get entityName(): string {
     return 'async_exports'
   }
 
@@ -76,7 +76,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
   public type?: AsyncExportPayload['type']
   public request?: AsyncExportPayload['request']
 
-  constructor (options: AsyncExportOptions) {
+  constructor(options: AsyncExportOptions) {
     super()
     this.universe = options.universe
     this.apiCarrier = options.universe
@@ -90,7 +90,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  protected deserialize (rawPayload: AsyncExportRawPayload): this {
+  protected deserialize(rawPayload: AsyncExportRawPayload): this {
     this.setRawPayload(rawPayload)
 
     this.type = rawPayload.type
@@ -100,11 +100,11 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     return this
   }
 
-  public static create (payload: AsyncExportRawPayload, universe: Universe, http: Universe['http']): AsyncExport {
+  public static create(payload: AsyncExportRawPayload, universe: Universe, http: Universe['http']): AsyncExport {
     return new AsyncExport({ rawPayload: payload, universe, http, initialized: true })
   }
 
-  public serialize (): AsyncExportRawPayload {
+  public serialize(): AsyncExportRawPayload {
     return {
       id: this.id,
       created_at: this.createdAt ? this.createdAt.toISOString() : undefined,
@@ -123,7 +123,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async init (): Promise<AsyncExport | undefined> {
+  public async init(): Promise<AsyncExport | undefined> {
     try {
       await this.fetch()
 
@@ -133,7 +133,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async createExport (payload: AsyncExportRawPayload | AsyncExportPayload): Promise<AsyncExportResponse> {
+  public async createExport(payload: AsyncExportRawPayload | AsyncExportPayload): Promise<AsyncExportResponse> {
     try {
       const opts = {
         method: 'POST',
@@ -162,7 +162,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async exports (options?: EntityFetchOptions): Promise<AsyncExport[] | AsyncExportRawPayload[] | undefined> {
+  public async exports(options?: EntityFetchOptions): Promise<AsyncExport[] | AsyncExportRawPayload[] | undefined> {
     try {
       const opts = {
         method: 'GET',
@@ -172,7 +172,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
         },
         params: options?.query,
         responseType: 'json',
-        timeout: options?.timeout ?? 10000
+        timeout: options?.timeout
       }
 
       const response = await this.http.getClient()(opts)
@@ -191,12 +191,12 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async exportsCount (options?: EntityFetchOptions): Promise<{ count: number } | undefined> {
+  public async exportsCount(options?: EntityFetchOptions): Promise<{ count: number } | undefined> {
     try {
       const opts = {
         method: 'HEAD',
         url: `${this.universe.universeBase}/${this.endpoint}`,
-        timeout: options?.timeout ?? 10000
+        timeout: options?.timeout
       }
 
       const res = await this.http.getClient()(opts)
@@ -208,7 +208,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async export (id: string, options?: UniverseFetchOptions): Promise<AsyncExport | AsyncExportRawPayload |undefined> {
+  public async export(id: string, options?: UniverseFetchOptions): Promise<AsyncExport | AsyncExportRawPayload | undefined> {
     try {
       const opts = {
         method: 'GET',
@@ -218,7 +218,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
         },
         params: options?.query,
         responseType: 'json',
-        timeout: options?.timeout ?? 10000
+        timeout: options?.timeout
       }
 
       const response = await this.http.getClient()(opts)
@@ -234,7 +234,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
 
 export class AsyncExportInitializationError extends BaseError {
   public name = 'AsyncExportInitializationError'
-  constructor (public message: string = 'Could not initialize async export.', properties?: any) {
+  constructor(public message: string = 'Could not initialize async export.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportInitializationError.prototype)
   }
@@ -242,7 +242,7 @@ export class AsyncExportInitializationError extends BaseError {
 
 export class AsyncExportFetchRemoteError extends BaseError {
   public name = 'AsyncExportFetchRemoteError'
-  constructor (public message: string = 'Could not get async export.', properties?: any) {
+  constructor(public message: string = 'Could not get async export.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportFetchRemoteError.prototype)
   }
@@ -250,7 +250,7 @@ export class AsyncExportFetchRemoteError extends BaseError {
 
 export class AsyncExportDeleteError extends BaseError {
   public name = 'AsyncExportDeleteError'
-  constructor (public message: string = 'Could not delete async export.', properties?: any) {
+  constructor(public message: string = 'Could not delete async export.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportDeleteError.prototype)
   }
@@ -258,7 +258,7 @@ export class AsyncExportDeleteError extends BaseError {
 
 export class AsyncExportsCountRemoteError extends BaseError {
   public name = 'AsyncExportsCountRemoteError'
-  constructor (public message: string = 'Could not get async exports count.', properties?: any) {
+  constructor(public message: string = 'Could not get async exports count.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportsCountRemoteError.prototype)
   }

--- a/src/entities/async-exports/async-export.ts
+++ b/src/entities/async-exports/async-export.ts
@@ -49,7 +49,7 @@ export interface AsyncExportPayload {
 }
 
 export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportRawPayload> {
-  public get entityName(): string {
+  public get entityName (): string {
     return 'async_exports'
   }
 
@@ -76,7 +76,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
   public type?: AsyncExportPayload['type']
   public request?: AsyncExportPayload['request']
 
-  constructor(options: AsyncExportOptions) {
+  constructor (options: AsyncExportOptions) {
     super()
     this.universe = options.universe
     this.apiCarrier = options.universe
@@ -90,7 +90,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  protected deserialize(rawPayload: AsyncExportRawPayload): this {
+  protected deserialize (rawPayload: AsyncExportRawPayload): this {
     this.setRawPayload(rawPayload)
 
     this.type = rawPayload.type
@@ -100,11 +100,11 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     return this
   }
 
-  public static create(payload: AsyncExportRawPayload, universe: Universe, http: Universe['http']): AsyncExport {
+  public static create (payload: AsyncExportRawPayload, universe: Universe, http: Universe['http']): AsyncExport {
     return new AsyncExport({ rawPayload: payload, universe, http, initialized: true })
   }
 
-  public serialize(): AsyncExportRawPayload {
+  public serialize (): AsyncExportRawPayload {
     return {
       id: this.id,
       created_at: this.createdAt ? this.createdAt.toISOString() : undefined,
@@ -123,7 +123,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async init(): Promise<AsyncExport | undefined> {
+  public async init (): Promise<AsyncExport | undefined> {
     try {
       await this.fetch()
 
@@ -133,7 +133,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async createExport(payload: AsyncExportRawPayload | AsyncExportPayload): Promise<AsyncExportResponse> {
+  public async createExport (payload: AsyncExportRawPayload | AsyncExportPayload): Promise<AsyncExportResponse> {
     try {
       const opts = {
         method: 'POST',
@@ -162,7 +162,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async exports(options?: EntityFetchOptions): Promise<AsyncExport[] | AsyncExportRawPayload[] | undefined> {
+  public async exports (options?: EntityFetchOptions): Promise<AsyncExport[] | AsyncExportRawPayload[] | undefined> {
     try {
       const opts = {
         method: 'GET',
@@ -191,7 +191,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async exportsCount(options?: EntityFetchOptions): Promise<{ count: number } | undefined> {
+  public async exportsCount (options?: EntityFetchOptions): Promise<{ count: number } | undefined> {
     try {
       const opts = {
         method: 'HEAD',
@@ -208,7 +208,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
     }
   }
 
-  public async export(id: string, options?: UniverseFetchOptions): Promise<AsyncExport | AsyncExportRawPayload | undefined> {
+  public async export (id: string, options?: UniverseFetchOptions): Promise<AsyncExport | AsyncExportRawPayload | undefined> {
     try {
       const opts = {
         method: 'GET',
@@ -234,7 +234,7 @@ export class AsyncExport extends UniverseEntity<AsyncExportPayload, AsyncExportR
 
 export class AsyncExportInitializationError extends BaseError {
   public name = 'AsyncExportInitializationError'
-  constructor(public message: string = 'Could not initialize async export.', properties?: any) {
+  constructor (public message: string = 'Could not initialize async export.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportInitializationError.prototype)
   }
@@ -242,7 +242,7 @@ export class AsyncExportInitializationError extends BaseError {
 
 export class AsyncExportFetchRemoteError extends BaseError {
   public name = 'AsyncExportFetchRemoteError'
-  constructor(public message: string = 'Could not get async export.', properties?: any) {
+  constructor (public message: string = 'Could not get async export.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportFetchRemoteError.prototype)
   }
@@ -250,7 +250,7 @@ export class AsyncExportFetchRemoteError extends BaseError {
 
 export class AsyncExportDeleteError extends BaseError {
   public name = 'AsyncExportDeleteError'
-  constructor(public message: string = 'Could not delete async export.', properties?: any) {
+  constructor (public message: string = 'Could not delete async export.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportDeleteError.prototype)
   }
@@ -258,7 +258,7 @@ export class AsyncExportDeleteError extends BaseError {
 
 export class AsyncExportsCountRemoteError extends BaseError {
   public name = 'AsyncExportsCountRemoteError'
-  constructor(public message: string = 'Could not get async exports count.', properties?: any) {
+  constructor (public message: string = 'Could not get async exports count.', properties?: any) {
     super(message, properties)
     Object.setPrototypeOf(this, AsyncExportsCountRemoteError.prototype)
   }

--- a/src/entities/contact-list/contact-list.ts
+++ b/src/entities/contact-list/contact-list.ts
@@ -276,7 +276,7 @@ export class ContactList extends UniverseEntity<ContactListPayload, ContactListR
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 10000
+        timeout: options?.timeout
       }
 
       const res = await this.http?.getClient()(opts)
@@ -302,7 +302,7 @@ export class ContactList extends UniverseEntity<ContactListPayload, ContactListR
       const opts = {
         method: 'HEAD',
         url: `${this.universe?.universeBase}/${this.endpoint}/${this.id as string}/preview${options?.query ? qs.stringify(options.query, { addQueryPrefix: true }) : ''}`,
-        timeout: options?.timeout ?? 10000
+        timeout: options?.timeout
       }
 
       const res = await this.http.getClient()(opts)
@@ -328,7 +328,7 @@ export class ContactList extends UniverseEntity<ContactListPayload, ContactListR
         },
         responseType: 'json',
         data: splitConfig,
-        timeout: options?.timeout ?? 30000
+        timeout: options?.timeout
       }
 
       const res = await this.http?.getClient()(opts)
@@ -349,7 +349,6 @@ export class ContactList extends UniverseEntity<ContactListPayload, ContactListR
   public async exportCsv (options?: UniverseExportCsvOptions): Promise<Blob> {
     const opts = {
       method: 'GET',
-      timeout: 60000,
       url: `${this.apiCarrier?.injectables?.base}/${this.endpoint}/${this.id as string}/preview/export${options?.query ? qs.stringify(options.query, { addQueryPrefix: true }) : ''}`,
       headers: {
         'Content-Type': 'application/json; charset=utf-8'

--- a/src/entities/message-broker/message-broker.ts
+++ b/src/entities/message-broker/message-broker.ts
@@ -340,7 +340,7 @@ export class MessageBroker extends UniverseEntity<MessageBrokerPayload, MessageB
     try {
       const opts = {
         method: 'PUT',
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout ,
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/profile`,
         headers: {
           'Content-Type': 'application/json; charset=utf-8',

--- a/src/entities/message-template/message-template.ts
+++ b/src/entities/message-template/message-template.ts
@@ -344,7 +344,7 @@ export class MessageTemplate extends UniverseEntity<MessageTemplatePayload, Mess
       const opts = {
         method: 'POST',
         url: `${this.universe?.universeBase}/${this.endpoint}/${this.id as string}/submit`,
-        timeout: options?.timeout ?? 30000,
+        timeout: options?.timeout,
         headers: {
           'Content-Type': 'application/json; charset=utf-8'
         },

--- a/src/entities/notification-campaign/notification-campaign.ts
+++ b/src/entities/notification-campaign/notification-campaign.ts
@@ -395,7 +395,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 60000
+        timeout: options?.timeout
       }
 
       const res = await this.http?.getClient()(opts)
@@ -420,7 +420,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 60000
+        timeout: options?.timeout
       }
       const res = await this.http.getClient()(opts)
       const data = res.data.data[0] as NotificationCampaignRawPayload
@@ -558,7 +558,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 120000
+        timeout: options?.timeout
       }
       const res = await this.http.getClient()(opts)
       return res.data.data as NotificationCampaignPreviewEntry[]
@@ -577,8 +577,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
         headers: {
           'Content-Type': 'application/json; charset=utf-8'
         },
-        responseType: 'json',
-        timeout: 120000
+        responseType: 'json'
       }
       const res = await this.http.getClient()(opts)
 
@@ -604,7 +603,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 60000
+        timeout: options?.timeout
       }
 
       const res = await this.http?.getClient()(opts)
@@ -738,7 +737,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout,
         data: body
       }
       const res = await this.http.getClient()(opts)
@@ -764,7 +763,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout
       }
       const res = await this.http.getClient()(opts)
       const data = res.data.data[0] as NotificationCampaignRawPayload
@@ -795,7 +794,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout,
         data: body
       }
       const res = await this.http.getClient()(opts)
@@ -826,7 +825,7 @@ export class NotificationCampaign extends UniverseEntity<NotificationCampaignPay
           'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json',
-        timeout: options?.timeout ?? 60000,
+        timeout: options?.timeout,
         data: body
       }
       const res = await this.http.getClient()(opts)

--- a/src/entities/person/person-contact.ts
+++ b/src/entities/person/person-contact.ts
@@ -314,7 +314,6 @@ export class PeopleContacts extends EntitiesList<PersonContact, PersonContactRaw
   public async _exportCsv (options?: EntitiesListExportCsvOptions): Promise<Blob> {
     const opts = {
       method: 'POST',
-      timeout: 60000,
       url: `${this.apiCarrier?.injectables?.base}/${this.endpoint}${options?.query ? qs.stringify(options.query, { addQueryPrefix: true }) : ''}`,
       headers: {
         Accept: 'text/csv'

--- a/src/entities/storefront/storefront.ts
+++ b/src/entities/storefront/storefront.ts
@@ -340,8 +340,7 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
           'Content-Type': 'application/json; charset=utf-8',
           'Content-Length': '0'
         },
-        responseType: 'json',
-        timeout: 60000
+        responseType: 'json'
       }
 
       const res = await this.http?.getClient()(opts)

--- a/src/universe/index.ts
+++ b/src/universe/index.ts
@@ -1224,7 +1224,7 @@ export class Universe extends APICarrier {
             params: {
               ...(options?.query ?? {})
             },
-            timeout: options?.timeout ?? 60000
+            timeout: options?.timeout
 
           }
 
@@ -1250,7 +1250,7 @@ export class Universe extends APICarrier {
             params: {
               ...(options?.query ?? {})
             },
-            timeout: options?.timeout ?? 60000
+            timeout: options?.timeout
           }
 
           const res = await this.http.getClient()(opts)


### PR DESCRIPTION
Removes the default http timeout of 10 seconds.

- Removed the default 10s HTTP timeout, which was causing issues where the backend continued processing requests after the UI had already timed out.
- Since we do not enforce timeouts on the backend, having a frontend timeout is not practical.
- Now relying on the infra default timeouts (cloudflare) for better synchronization between the UI and backend responses.