### PR TITLE
fix: remove content length chrom blocks it

### DIFF
--- a/src/entities/automation-engine/automation-engine.ts
+++ b/src/entities/automation-engine/automation-engine.ts
@@ -206,8 +206,7 @@ export class AutomationEngine extends UniverseEntity<AutomationEnginePayload, Au
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/flows`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -227,8 +226,7 @@ export class AutomationEngine extends UniverseEntity<AutomationEnginePayload, Au
         method: 'GET',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/flows`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -249,8 +247,7 @@ export class AutomationEngine extends UniverseEntity<AutomationEnginePayload, Au
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/flows/${flowId}/trigger`,
         data,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }

--- a/src/entities/crm/crm.ts
+++ b/src/entities/crm/crm.ts
@@ -156,8 +156,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/custom_properties`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -177,8 +176,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/deals`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -198,8 +196,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/channel_users`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -219,8 +216,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/contact_lists`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -240,8 +236,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/contact_list_static_entries`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -261,8 +256,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/pipelines`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -282,8 +276,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/people_organizations`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -303,8 +296,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/setup`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -324,8 +316,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/users`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -345,8 +336,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'GET',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/users${qs.stringify(options?.query ?? {}, { addQueryPrefix: true })}`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -374,8 +364,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'POST',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/users/associate`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         data,
         responseType: 'json'
@@ -423,8 +412,7 @@ export class CRM extends UniverseEntity<CRMPayload, CRMRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/contact_list_static_entries/${contactListId}`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }

--- a/src/entities/form-provider/form-provider.ts
+++ b/src/entities/form-provider/form-provider.ts
@@ -156,8 +156,7 @@ export class FormProvider extends UniverseEntity<FormProviderPayload, FormProvid
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/form_instances`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }

--- a/src/entities/message-broker/message-broker.ts
+++ b/src/entities/message-broker/message-broker.ts
@@ -256,8 +256,7 @@ export class MessageBroker extends UniverseEntity<MessageBrokerPayload, MessageB
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id as string}/sync/message_templates`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -276,8 +275,7 @@ export class MessageBroker extends UniverseEntity<MessageBrokerPayload, MessageB
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/messages`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -297,8 +295,7 @@ export class MessageBroker extends UniverseEntity<MessageBrokerPayload, MessageB
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/messages/${externalPersonReferenceId}`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -340,11 +337,10 @@ export class MessageBroker extends UniverseEntity<MessageBrokerPayload, MessageB
     try {
       const opts = {
         method: 'PUT',
-        timeout: options?.timeout ,
+        timeout: options?.timeout,
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/profile`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         data: {
           ...(payload ?? undefined)

--- a/src/entities/nlu/nlu.ts
+++ b/src/entities/nlu/nlu.ts
@@ -163,8 +163,7 @@ export class Nlu extends UniverseEntity<NluPayload, NluRawPayload> {
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id as string}/sync/intents`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }

--- a/src/entities/storefront/storefront.ts
+++ b/src/entities/storefront/storefront.ts
@@ -170,8 +170,7 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/products`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
         },
         responseType: 'json'
       }
@@ -190,8 +189,8 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/orders`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
+
         },
         responseType: 'json'
       }
@@ -210,8 +209,8 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/channel_users`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
+
         },
         responseType: 'json'
       }
@@ -230,8 +229,8 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/inventories`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
+
         },
         responseType: 'json'
       }
@@ -250,8 +249,8 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/locations`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
+
         },
         responseType: 'json'
       }
@@ -270,8 +269,8 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/product_categories`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
+
         },
         responseType: 'json'
       }
@@ -290,8 +289,8 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'PUT',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/sync/shipping_methods`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
+
         },
         responseType: 'json'
       }
@@ -337,8 +336,8 @@ export class Storefront extends UniverseEntity<StorefrontPayload, StorefrontRawP
         method: 'POST',
         url: `${this.universe.universeBase}/${this.endpoint}/${this.id}/uninstall`,
         headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'Content-Length': '0'
+          'Content-Type': 'application/json; charset=utf-8'
+
         },
         responseType: 'json'
       }


### PR DESCRIPTION
Ticket:
 https://hello-charles-team.atlassian.net/browse/OCT-12468
 
 Discovered when trying to the the klaviyo sync for purelei

When clicking events it seems some are blocked because the of the content length, the browsers calculate these automatically. 

<img width="775" alt="Screenshot 2025-06-18 at 17 45 10" src="https://github.com/user-attachments/assets/f0e70632-c19d-4753-8c46-7187ea27c251" />
