### PR TITLE
feat: add getOperatorUniversesV2

### DIFF
--- a/src/cloud/entities/universe/index.ts
+++ b/src/cloud/entities/universe/index.ts
@@ -6,7 +6,10 @@ import {
   CloudUniversesFetchRemoteError,
   OperatorUniverse,
   OperatorUniverseResponse,
-  OperatorUniverseError
+  OperatorUniverseError,
+  OperatorMtUniverse,
+  OperatorMtUniverseResponse,
+  OperatorUniverseResponseV2
 } from './universe'
 
 export {
@@ -16,5 +19,8 @@ export {
   CloudUniversesFetchRemoteError,
   OperatorUniverse,
   OperatorUniverseResponse,
-  OperatorUniverseError
+  OperatorUniverseError,
+  OperatorMtUniverse,
+  OperatorMtUniverseResponse,
+  OperatorUniverseResponseV2
 }

--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -55,6 +55,7 @@ export type DeployReleaseResponse = SingleDeployReleaseResponse | [SingleDeployR
 
 export interface OperatorUniverse {
   readonly id: string
+  readonly mt: boolean
   readonly name: string
   readonly pool: string
   readonly organization: string
@@ -75,6 +76,22 @@ export interface OperatorUniverse {
 }
 
 export type OperatorUniverseResponse = OperatorUniverse | [OperatorUniverse]
+
+export interface OperatorMtUniverse {
+  readonly id: string
+  readonly mt: boolean
+  readonly name: string
+  readonly organization: string
+  readonly createdAt: string
+  // readonly status: string
+  // readonly applied: boolean
+  // readonly isLive: boolean
+  readonly rawCrd: any
+}
+
+export type OperatorMtUniverseResponse = OperatorMtUniverse | [OperatorMtUniverse]
+
+export type OperatorUniverseResponseV2 = [OperatorUniverse | OperatorMtUniverse]
 
 export interface ReleaseHistoryResponse {
   readonly id: string

--- a/src/cloud/index.ts
+++ b/src/cloud/index.ts
@@ -460,6 +460,26 @@ export class Cloud extends APICarrier {
     }
   }
 
+  public async operatorUniversesV2 (qs?: string): Promise<universe.OperatorUniverseResponseV2> {
+    try {
+      const res = await this.http.getClient().get(`${this.cloudBase}/api/v0/universes/operator/v2${qs && typeof qs === 'string' ? `?${qs}` : ''}`)
+
+      return res.data?.data
+    } catch (err) {
+      throw new universe.OperatorUniverseError()
+    }
+  }
+
+  public async operatorChurnedUniversesV2 (): Promise<universe.OperatorUniverseResponseV2> {
+    try {
+      const res = await this.http.getClient().get(`${this.cloudBase}/api/v0/universes/operator/v2?churned=true`)
+
+      return res.data?.data
+    } catch (err) {
+      throw new universe.OperatorUniverseError()
+    }
+  }
+
   public async configuration (): Promise<any> {
     try {
       const res = await this.http.getClient().get(`${this.cloudBase}/api/v0/configuration`)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added new operatorUniversesV2 and operatorChurnedUniversesV2 methods to fetch updated operator universe data, including support for MT universes.

- **New Features**
  - Added OperatorMtUniverse and related response types.
  - Exposed new API methods for fetching operator universes (v2) and churned universes.

<!-- End of auto-generated description by cubic. -->

