### PR TITLE
feat: add support for get one mt uni route

### DIFF
--- a/src/cloud/entities/universe/universe.ts
+++ b/src/cloud/entities/universe/universe.ts
@@ -149,7 +149,7 @@ export interface CloudUniverseRawPayload {
   readonly status?: object
   readonly release?: string | null
   readonly migrated?: boolean | null
-	readonly tenancy?: 'SINGLE' | 'MULTI'
+  readonly tenancy?: 'SINGLE' | 'MULTI'
   readonly host?: string | null
 
 }
@@ -168,7 +168,7 @@ export interface CloudUniversePayload {
   readonly status?: CloudUniverseRawPayload['status']
   readonly release?: CloudUniverseRawPayload['release']
   readonly migrated?: CloudUniverseRawPayload['migrated']
-	readonly tenancy: 'SINGLE' | 'MULTI'
+  readonly tenancy: 'SINGLE' | 'MULTI'
   readonly host?: string | null
 }
 
@@ -212,8 +212,8 @@ export interface SaveMultipleResponse {
 
 export interface SaveMultiTenantPayload {
   readonly name: string
-	readonly organization: string
-	readonly host: string
+  readonly organization: string
+  readonly host: string
 }
 
 /**
@@ -246,7 +246,7 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
   public status?: CloudUniversePayload['status']
   public release?: CloudUniversePayload['release']
   public migrated?: CloudUniversePayload['migrated']
-	public tenancy: 'SINGLE' | 'MULTI' = 'SINGLE'
+  public tenancy: 'SINGLE' | 'MULTI' = 'SINGLE'
   public host?: string | null
 
   constructor (options: CloudUniverseOptions) {
@@ -321,8 +321,8 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
     this.status = rawPayload.status
     this.release = rawPayload.release
     this.migrated = rawPayload.migrated
-		this.tenancy = rawPayload.tenancy ?? 'SINGLE'
-		this.host = rawPayload.host ?? null
+    this.tenancy = rawPayload.tenancy ?? 'SINGLE'
+    this.host = rawPayload.host ?? null
     return this
   }
 
@@ -540,48 +540,48 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
     }
   }
 
-	public async saveMultiTenant (payload: SaveMultiTenantPayload): Promise<CloudUniverse> {
-		const endpoint = `api/v0/mt-universes`
-		try {
-			const opts = {
-				method: 'POST',
-				url: `${this.apiCarrier?.injectables?.base}/${endpoint}`,
-				headers: {
-					'Content-Type': 'application/json; charset=utf-8'
-				},
-				responseType: 'json',
-				data: payload
-			}
-			const res = await this.http?.getClient()(opts)
-			if (res.status !== 200) {
-				throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError(undefined, { error: res.data }))
-			}
-			this.deserialize(res.data.data as CloudUniverseRawPayload)
-			return this
-		} catch (err) {
-			throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError(undefined, { error: err }))
-		}
-	}
+  public async saveMultiTenant (payload: SaveMultiTenantPayload): Promise<CloudUniverse> {
+    const endpoint = `api/v0/mt-universes`
+    try {
+      const opts = {
+        method: 'POST',
+        url: `${this.apiCarrier?.injectables?.base}/${endpoint}`,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
+        responseType: 'json',
+        data: payload
+      }
+      const res = await this.http?.getClient()(opts)
+      if (res.status !== 200) {
+        throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError(undefined, { error: res.data }))
+      }
+      this.deserialize(res.data.data as CloudUniverseRawPayload)
+      return this
+    } catch (err) {
+      throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError(undefined, { error: err }))
+    }
+  }
 
-	public async deployMultiTenant (): Promise<void> {
-		const endpoint = `api/v0/mt-universes/${this.id}/deploy`
-		try {
-			const opts = {
-				method: 'POST',
-				url: `${this.apiCarrier?.injectables?.base}/${endpoint}`,
-				headers: {
-					'Content-Type': 'application/json; charset=utf-8'
-				},
-				responseType: 'json'
-			}
-			const res = await this.http?.getClient()(opts)
-			if (res.status !== 200) {
-				throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError())
-			}
-		} catch (err) {
-			throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError(undefined, { error: err }))
-		}
-	}
+  public async deployMultiTenant (): Promise<void> {
+    const endpoint = `api/v0/mt-universes/${this.id}/deploy`
+    try {
+      const opts = {
+        method: 'POST',
+        url: `${this.apiCarrier?.injectables?.base}/${endpoint}`,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
+        responseType: 'json'
+      }
+      const res = await this.http?.getClient()(opts)
+      if (res.status !== 200) {
+        throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError())
+      }
+    } catch (err) {
+      throw this.handleError(new CloudUniverseDeployFromUniverseConfigRemoteError(undefined, { error: err }))
+    }
+  }
 
   public async operatorUniverses (): Promise<OperatorUniverseResponse> {
     const operatorEndpoint = 'api/v0/universes/operator'
@@ -607,7 +607,7 @@ export class CloudUniverse extends Entity<CloudUniversePayload, CloudUniverseRaw
   }
 
   public async fetchCrd (): Promise<OperatorUniverseResponse> {
-    const operatorEndpoint = `api/v0/universes/operator/${this.id}`
+    const operatorEndpoint =  `api/v0/${this.tenancy === 'SINGLE' ? 'universes' : 'mt-universes'}/operator/${this.id}`
     try {
       const opts = {
         method: 'GET',


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for fetching a single multi-tenant universe by updating the operator endpoint to use the correct route based on tenancy type. This allows proper retrieval of operator data for both single and multi-tenant universes.

<!-- End of auto-generated description by cubic. -->

